### PR TITLE
Implement a chatbot service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java'
+    id 'org.springframework.boot' version '3.1.0'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'org.example'
@@ -10,12 +12,31 @@ repositories {
 }
 
 dependencies {
+    // Spring Web 라이브러리 (Rest API 기능 제공)
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Jackson 라이브러리 (JSON 직렬화 및 역직렬화)
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
+
+    // OkHttp3 클라이언트 라이브러리 (HTTP 요청 전송)
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+
+    // Lombok (게터/세터 자동 생성, 가독성 개선)
+    compileOnly 'org.projectlombok:lombok:1.18.34'
+    annotationProcessor 'org.projectlombok:lombok:1.18.34'
+
+    testCompileOnly 'org.projectlombok:lombok:1.18.34'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.34'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-core:3.7.7'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.7.7'
+    testImplementation 'org.springframework:spring-test'
+
+    // Hamcrest for matchers
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+
 }
 
 test {

--- a/src/main/java/org/example/ChatGptChatbotApplication.java
+++ b/src/main/java/org/example/ChatGptChatbotApplication.java
@@ -1,0 +1,11 @@
+package org.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ChatGptChatbotApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ChatGptChatbotApplication.class, args);
+    }
+}

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -1,7 +1,0 @@
-package org.example;
-
-public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/src/main/java/org/example/controller/ChatGptController.java
+++ b/src/main/java/org/example/controller/ChatGptController.java
@@ -1,0 +1,26 @@
+package org.example.controller;
+
+import org.example.service.ChatGptService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/chat")
+public class ChatGptController {
+
+    @Autowired
+    private ChatGptService chatGptService;
+
+    @PostMapping("/send")
+    public String sendMessage(@RequestBody Map<String, String> request) {
+        String userMessage = request.get("message");
+        try {
+            return chatGptService.askChatGpt(userMessage);
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
+    }
+
+}

--- a/src/main/java/org/example/service/ChatGptService.java
+++ b/src/main/java/org/example/service/ChatGptService.java
@@ -1,0 +1,56 @@
+package org.example.service;
+
+import okhttp3.*;
+import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ChatGptService {
+
+    private static final String API_KEY = "";
+    private static final String API_URL = "https://api.openai.com/v1/chat/completions";  // 수정된 URL
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String askChatGpt(String prompt) throws IOException {
+        // 요청 바디 생성
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-3.5-turbo");  // 사용할 모델
+        requestBody.put("messages", new Object[]{
+                new HashMap<String, String>() {{
+                    put("role", "user");
+                    put("content", prompt);
+                }}
+        });
+        requestBody.put("max_tokens", 200);
+
+        String jsonBody = objectMapper.writeValueAsString(requestBody);
+
+        // 요청 빌드
+        Request request = new Request.Builder()
+                .url(API_URL)
+                .post(RequestBody.create(jsonBody, MediaType.get("application/json")))
+                .addHeader("Authorization", "Bearer " + API_KEY)
+                .build();
+
+        // 요청 전송 및 응답 처리
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("Unexpected code " + response);
+            }
+
+            String responseBody = response.body().string();
+            // 응답 바디를 JSON으로 변환하고 필요한 값을 추출
+            Map<String, Object> responseMap = objectMapper.readValue(responseBody, Map.class);
+            Map<String, Object> choice = (Map<String, Object>) ((List<Object>) responseMap.get("choices")).get(0);
+            Map<String, Object> message = (Map<String, Object>) choice.get("message");
+            return message.get("content").toString();
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=8080

--- a/src/test/java/org/example/controller/ChatGptControllerTest.java
+++ b/src/test/java/org/example/controller/ChatGptControllerTest.java
@@ -1,0 +1,66 @@
+package org.example.controller;
+
+import org.example.service.ChatGptService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ChatGptControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ChatGptService chatGptService;
+
+    @InjectMocks
+    private ChatGptController chatGptController;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(chatGptController).build();
+    }
+
+    @Test
+    public void testSendMessage_Success() throws Exception {
+        // Mock 설정
+        when(chatGptService.askChatGpt("Hello")).thenReturn("[{text=Hello}]");
+
+        // 요청 데이터 준비
+        Map<String, String> requestData = new HashMap<>();
+        requestData.put("message", "Hello");
+
+        // POST 요청을 통해 컨트롤러 테스트
+        mockMvc.perform(post("/chat/send")
+                        .contentType("application/json")
+                        .content("{\"message\": \"Hello\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("[{text=Hello}]"));
+    }
+
+    @Test
+    public void testSendMessage_Error() throws Exception {
+        // Mock 설정
+        when(chatGptService.askChatGpt("Hello")).thenThrow(new IOException("API Error"));
+
+        // POST 요청을 통해 에러 처리 테스트
+        mockMvc.perform(post("/chat/send")
+                        .contentType("application/json")
+                        .content("{\"message\": \"Hello\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Error: API Error"));
+    }
+}

--- a/src/test/java/org/example/service/ChatGptServiceTest.java
+++ b/src/test/java/org/example/service/ChatGptServiceTest.java
@@ -1,0 +1,53 @@
+package org.example.service;
+
+import okhttp3.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class ChatGptServiceTest {
+
+    @Mock
+    private OkHttpClient client;
+
+    @Mock
+    private Call call;
+
+    @InjectMocks
+    private ChatGptService chatGptService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testAskChatGpt_Success() throws IOException {
+        // 준비: Mock 응답 설정
+        Response mockResponse = new Response.Builder()
+                .request(new Request.Builder().url("https://api.openai.com/v1/completions").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create("{\"choices\":[{\"text\":\"Hello\"}]}", MediaType.get("application/json")))
+                .build();
+
+        when(client.newCall(any(Request.class))).thenReturn(call);
+        when(call.execute()).thenReturn(mockResponse);
+
+        // 실행
+        String result = chatGptService.askChatGpt("Hello");
+
+        // 검증
+        assertEquals("Hello! How can I help you today?", result);
+        verify(client, times(1)).newCall(any(Request.class));
+    }
+
+}


### PR DESCRIPTION
Implement a chatbot service.

* Implemented ChatGptService to interact with OpenAI's GPT-3.5-turbo model using OkHttpClient.
* Added ChatGptController to expose a /chat/send endpoint for sending user prompts to ChatGPT and receiving responses.
* Created unit tests for both the service (ChatGptServiceTest) and controller (ChatGptControllerTest) to verify functionality and error handling.

This closes #5 